### PR TITLE
Fixed file extension handling

### DIFF
--- a/ExcalidrawInVisualStudio/Constants.cs
+++ b/ExcalidrawInVisualStudio/Constants.cs
@@ -5,6 +5,6 @@
         public const string MarketplaceUrl = "https://marketplace.visualstudio.com/items?itemName=PhilipHendry.philiphendry-excalidraw";
         public const string LanguageName = "Excalidraw";
         public const string FileExtension = ".excalidraw";
-        public const string FileExtensionEmbeddedImage = ".excalidrawpng";
+        public const string FileExtensionEmbeddedImage = ".excalidraw.png";
     }
 }

--- a/ExcalidrawInVisualStudio/ExcalidrawInVisualStudio.csproj
+++ b/ExcalidrawInVisualStudio/ExcalidrawInVisualStudio.csproj
@@ -138,7 +138,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="VSPackage.resx" />
+    <EmbeddedResource Include="VSPackage.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/ExcalidrawInVisualStudio/ExcalidrawPackage.cs
+++ b/ExcalidrawInVisualStudio/ExcalidrawPackage.cs
@@ -10,13 +10,11 @@ namespace ExcalidrawInVisualStudio
     [InstalledProductRegistration(Vsix.Name, Vsix.Description, Vsix.Version)]
     [Guid(PackageGuids.ExcalidrawEditorString)]
 
-    [ProvideLanguageExtension(typeof(EditorFactory), Constants.FileExtension)]
-    [ProvideLanguageExtension(typeof(EditorFactory), Constants.FileExtensionEmbeddedImage)]
-
     [ProvideEditorFactory(typeof(EditorFactory), 100)]
     [ProvideEditorLogicalView(typeof(EditorFactory), VSConstants.LOGVIEWID.ProjectSpecificEditor_string, IsTrusted = true)]
     [ProvideEditorExtension(typeof(EditorFactory), Constants.FileExtension, 50)]
     [ProvideEditorExtension(typeof(EditorFactory), Constants.FileExtensionEmbeddedImage, 50)]
+    [ProvideEditorExtension(typeof(EditorFactory), ".png", 1)]
 
     [ProvideFileIcon(Constants.FileExtension, "ef43980f-62d6-42ba-9f24-20ea2285663b:1")]
     [ProvideBindingPath]

--- a/ExcalidrawInVisualStudio/ExcalidrawWindowPane.cs
+++ b/ExcalidrawInVisualStudio/ExcalidrawWindowPane.cs
@@ -172,12 +172,11 @@ public class ExcalidrawWindowPane :
 
     private void LoadScene()
     {
+        SetFileChangeNotification(_filename, false);
         _isDirty = false;
 
         ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
         {
-            SetFileChangeNotification(_filename, false);
-
             await _webViewInitialisedTaskSource.Task.WithTimeout(TimeSpan.FromSeconds(WaitForWebViewTimeOutInSeconds));
 
             if (_filename.EndsWith(Constants.FileExtensionEmbeddedImage, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This allows the extension `.excalidraw.png` to be used but given `.png` will already be associated to an image editor I've ensured the "Excalidraw Editor" option is available in the "Open with..." dialog and the user can set it as default if they want. This improves the features detailed in #9 